### PR TITLE
update bcrypto and remove bsip.

### DIFF
--- a/lib/golomb.js
+++ b/lib/golomb.js
@@ -9,7 +9,7 @@
 const assert = require('bsert');
 const {U64} = require('n64');
 const hash256 = require('bcrypto/lib/hash256');
-const {sipmod} = require('bsip');
+const {sipmod} = require('bcrypto/lib/siphash');
 const BitWriter = require('./writer');
 const BitReader = require('./reader');
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,8 @@
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "dependencies": {
-    "bcrypto": "~3.1.0",
+    "bcrypto": "~4.0.1",
     "bsert": "~0.0.10",
-    "bsip": "~0.1.8",
     "n64": "~0.2.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates bcrypto,

Now we can use `siphash` from `bcrypto` instead of `bsip`.
https://github.com/bcoin-org/bcrypto/issues/22
