### PR TITLE
golomb: add jsdocs

### DIFF
--- a/lib/golomb.js
+++ b/lib/golomb.js
@@ -23,7 +23,13 @@ const EOF = new U64(-1);
 const M = new U64(784931);
 
 /**
- * Golomb Filter
+ * Golomb - BIP 158 block filters
+ * @alias module:golomb.Golomb
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki
+ * @property {Number} m
+ * @property {Number} n
+ * @property {Number} p
+ * @property {Buffer} data
  */
 
 class Golomb {
@@ -39,14 +45,34 @@ class Golomb {
     this.data = DUMMY;
   }
 
+  /**
+   * Hash the block filter.
+   * @param {String?} enc - Can be `'hex'` or `null`.
+   * @returns {Hash|Buffer} hash
+   */
+
   hash(enc) {
     const h = hash256.digest(this.toNBytes());
     return enc === 'hex' ? h.toString('hex') : h;
   }
 
+  /**
+   * Get the block filter header.
+   * hash of block filter concatenated with previous block filter header.
+   * @param {Hash} prev - previous filter header.
+   * @returns {Hash|Buffer} hash
+   */
+
   header(prev) {
     return hash256.root(this.hash(), prev);
   }
+
+  /**
+   * Get the membership of given item in the block filter.
+   * @param {Buffer} key - 128-bit key.
+   * @param {Buffer} data - item.
+   * @returns {Boolean} match
+   */
 
   match(key, data) {
     const br = new BitReader(this.data);
@@ -70,6 +96,13 @@ class Golomb {
 
     return false;
   }
+
+  /**
+   * Get the membership of any item of given items in the block filter.
+   * @param {Buffer} key - 128-bit key.
+   * @param {Buffer[]} items.
+   * @returns {Boolean} match
+   */
 
   matchAny(key, items) {
     const set = uniqify(items);
@@ -117,6 +150,11 @@ class Golomb {
     return true;
   }
 
+  /**
+   * Read uint64 from a bit reader.
+   * @param {BufferReader} br {@link BitReader}
+   */
+
   readU64(br) {
     try {
       return this._readU64(br);
@@ -126,6 +164,12 @@ class Golomb {
       throw e;
     }
   }
+
+  /**
+   * Read uint64 from a bit reader.
+   * @param {BufferReader} br {@link BitReader}
+   * @throws on EOF
+   */
 
   _readU64(br) {
     const num = new U64(0);
@@ -139,9 +183,19 @@ class Golomb {
     return num.ishln(this.p).ior(rem);
   }
 
+  /**
+   * Serialize the block filter as raw filter bytes.
+   * @returns {Buffer} filter
+   */
+
   toBytes() {
     return this.data;
   }
+
+  /**
+   * Serialize the block filter as N and raw filter bytes
+   * @returns {Buffer} filter
+   */
 
   toNBytes() {
     const size = bio.sizeVarint(this.n) + this.data.length;
@@ -153,12 +207,22 @@ class Golomb {
     return bw.render();
   }
 
+  /**
+   * Serialize the block filter as P and raw filter bytes
+   * @returns {Buffer} filter
+   */
+
   toPBytes() {
     const data = Buffer.allocUnsafe(1 + this.data.length);
     data.writeUInt8(this.p, 0);
     this.data.copy(data, 1);
     return data;
   }
+
+  /**
+   * Serialize the block filter as N, P and raw filter bytes
+   * @returns {Buffer} filter
+   */
 
   toNPBytes() {
     const data = Buffer.allocUnsafe(5 + this.data.length);
@@ -168,10 +232,23 @@ class Golomb {
     return data;
   }
 
+  /**
+   * Serialize the block filter as default filter bytes.
+   * @returns {Buffer} filter
+   */
+
   toRaw() {
     assert(this.p === 19);
     return this.toNBytes();
   }
+
+  /**
+   * Instantiate a block filter from a P, 128-bit key and items.
+   * @param {Number} P
+   * @param {Buffer} 128-bit key
+   * @param {Buffer[]} items
+   * @returns {Golomb}
+   */
 
   fromItems(P, key, items) {
     assert((P >>> 0) === P);
@@ -223,6 +300,14 @@ class Golomb {
     return this;
   }
 
+  /**
+   * Instantiate a block filter from a N, P, and raw data.
+   * @param {Number} N
+   * @param {Number} P
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
+
   fromBytes(N, P, data) {
     assert((N >>> 0) === N);
     assert((P >>> 0) === P);
@@ -237,6 +322,13 @@ class Golomb {
     return this;
   }
 
+  /**
+   * Instantiate a block filter from a P, and raw data.
+   * @param {Number} P
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
+
   fromNBytes(P, data) {
     const br = bio.read(data);
     const N = br.readVarint();
@@ -244,6 +336,13 @@ class Golomb {
 
     return this.fromBytes(N, P, body);
   }
+
+  /**
+   * Instantiate a block filter from a N, and raw data.
+   * @param {Number} N
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
 
   fromPBytes(N, data) {
     assert(Buffer.isBuffer(data));
@@ -253,6 +352,12 @@ class Golomb {
 
     return this.fromBytes(N, P, data.slice(1));
   }
+
+  /**
+   * Instantiate a block filter from raw data.
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
 
   fromNPBytes(data) {
     assert(Buffer.isBuffer(data));
@@ -264,29 +369,77 @@ class Golomb {
     return this.fromBytes(N, P, data.slice(5));
   }
 
+  /**
+   * Instantiate a block filter from raw data.
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
+
   fromRaw(data) {
     return this.fromNBytes(19, data);
   }
+
+  /**
+   * Instantiate a block filter from a P, 128-bit key and items.
+   * @param {Number} P
+   * @param {Buffer} 128-bit key
+   * @param {Buffer[]} items
+   * @returns {Golomb}
+   */
 
   static fromItems(P, key, items) {
     return new this().fromItems(P, key, items);
   }
 
+  /**
+   * Instantiate a block filter from a N, P, and raw data.
+   * @param {Number} N
+   * @param {Number} P
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
+
   static fromBytes(N, P, data) {
     return new this().fromBytes(N, P, data);
   }
+
+  /**
+   * Instantiate a block filter from a P, and raw data.
+   * @param {Number} P
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
 
   static fromNBytes(P, data) {
     return new this().fromNBytes(P, data);
   }
 
+  /**
+   * Instantiate a block filter from a N, and raw data.
+   * @param {Number} N
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
+
   static fromPBytes(N, data) {
     return new this().fromPBytes(N, data);
   }
 
+  /**
+   * Instantiate a block filter from raw data.
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
+
   static fromNPBytes(data) {
     return new this().fromNPBytes(data);
   }
+
+  /**
+   * Instantiate a block filter from raw data.
+   * @param {Buffer} data
+   * @returns {Golomb}
+   */
 
   static fromRaw(data) {
     return new this().fromRaw(data);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -10,7 +10,8 @@ const assert = require('bsert');
 const {U64} = require('n64');
 
 /**
- * Bit Reader
+ * Bit Reader - as specified by BIP 158 for Golomb Rice Coding
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#golomb-rice-coding
  */
 
 class BitReader {
@@ -25,6 +26,10 @@ class BitReader {
     this.pos = 0;
     this.remain = 8;
   }
+  /**
+   * Read bit.
+   * @returns {Buffer} bit
+   */
 
   readBit() {
     if (this.pos >= this.stream.length)
@@ -43,6 +48,11 @@ class BitReader {
 
     return (this.stream[this.pos] >> this.remain) & 1;
   }
+
+  /**
+   * Read byte.
+   * @returns {Buffer} data
+   */
 
   readByte() {
     if (this.pos >= this.stream.length)
@@ -76,6 +86,11 @@ class BitReader {
     return ch;
   }
 
+  /**
+   * Read bits.
+   * @returns {Buffer} data
+   */
+
   readBits(count) {
     assert(count >= 0);
     assert(count <= 32);
@@ -96,6 +111,11 @@ class BitReader {
 
     return num;
   }
+
+  /**
+   * Read bits. 64-bit.
+   * @returns {Buffer} data
+   */
 
   readBits64(count) {
     assert(count >= 0);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -9,7 +9,8 @@
 const assert = require('bsert');
 
 /**
- * Bit Writer
+ * Bit Writer - as specified by BIP 158 for Golomb Rice Coding
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#golomb-rice-coding
  */
 
 class BitWriter {
@@ -23,6 +24,11 @@ class BitWriter {
     this.stream = [];
     this.remain = 0;
   }
+
+  /**
+   * Write bit.
+   * @param {Buffer} bit
+   */
 
   writeBit(bit) {
     if (this.remain === 0) {
@@ -38,6 +44,11 @@ class BitWriter {
     this.remain--;
   }
 
+  /**
+   * Write byte.
+   * @param {Buffer} ch
+   */
+
   writeByte(ch) {
     if (this.remain === 0) {
       this.stream.push(0);
@@ -50,6 +61,12 @@ class BitWriter {
     this.stream.push(0);
     this.stream[index + 1] = (ch << this.remain) & 0xff;
   }
+
+  /**
+   * Write bits.
+   * @param {Number} num
+   * @param {Number} count
+   */
 
   writeBits(num, count) {
     assert(count >= 0);
@@ -72,6 +89,12 @@ class BitWriter {
     }
   }
 
+  /**
+   * Write bits. 64-bit.
+   * @param {Number} num
+   * @param {Number} count
+   */
+
   writeBits64(num, count) {
     assert(count >= 0);
     assert(count <= 64);
@@ -83,6 +106,11 @@ class BitWriter {
       this.writeBits(num.lo, count);
     }
   }
+
+  /**
+   * Allocate and render the final buffer.
+   * @returns {Buffer} Rendered buffer.
+   */
 
   render() {
     const data = Buffer.allocUnsafe(this.stream.length);


### PR DESCRIPTION
Ports jsdocs from `bcoin/lib/golomb`.

This module was pulled into `bcoin` to add support for BIP 158.
